### PR TITLE
add db scripts

### DIFF
--- a/bin/pop-db
+++ b/bin/pop-db
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+STASH_PATH=backups/stash.sql.gz
+
+if [ ! -f .env ]; then
+  echo "Missing .env file!"
+  exit 1
+fi
+
+if [ ! -f $STASH_PATH ]; then
+  echo "No stashed db found at '$STASH_PATH'"
+  exit 1
+fi
+
+# Source local DB credentials from dotenv file
+source .env
+
+docker-compose start
+
+echo "Restoring database from stash ..."
+cat $STASH_PATH | gunzip | docker-compose exec -T db mysql -u$DB_USER -p$DB_PASSWORD $DB_DATABASE
+rm $STASH_PATH
+
+docker-compose stop

--- a/bin/stash-db
+++ b/bin/stash-db
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+STASH_PATH=backups/stash.sql.gz
+
+if [ ! -f .env ]; then
+  echo "Missing .env file!"
+  exit 1
+fi
+
+if [ -f $STASH_PATH ]; then
+  echo "A stashed version of your database already exists at '$STASH_PATH'"
+  echo "Please remove it before running this script"
+  exit 1
+fi
+
+# Source local DB credentials from dotenv file
+source .env
+
+docker-compose start
+
+echo "Stashing local database ..."
+docker-compose exec -T db mysqldump -u$DB_USER -p$DB_PASSWORD $DB_DATABASE | gzip > $STASH_PATH
+
+docker-compose stop

--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Usage: ./scripts/pull.sh [environment]
+#
+# Pulls database and local assets from target environment into current environment.
+#
+
+set -e
+
+FROM=${1:-prod}
+FROM=$(echo $FROM | awk '{print toupper($0)}')
+
+# Load Craft environment variables for current environment.
+if [ -f .env ]; then
+    source .env
+else
+    echo "Missing .env file!"
+    exit 1
+fi
+
+# Define all variables required for pull ops.
+source scripts/vars.sh
+
+main() {
+    echo "Starting craft pull from $FROM ..."
+    echo "............................"
+
+    pull_craft_db
+    pull_craft_assets
+    clear_craft_caches
+
+    echo "............................"
+    echo "Craft pull complete!"
+}
+
+pull_craft_db() {
+    echo "Pulling craft database ..."
+
+    echo "Dumping remote database ..."
+    if [ $FROM_SSH_USER ]; then
+        ssh $FROM_SSH_USER@$FROM_SSH_HOST "$FROM_MYSQLDUMP | gzip -c" | gunzip > $FROM_DB_DATABASE.sql
+    else
+        $FROM_MYSQLDUMP > $FROM_DB_DATABASE.sql
+    fi
+
+    echo "Backing up local database ..."
+    $MYSQLDUMP > $TO_DB_DATABASE.sql
+
+    echo "Dropping local database ..."
+    $MYSQL -e "DROP DATABASE $TO_DB_DATABASE; CREATE DATABASE $TO_DB_DATABASE;"
+
+    echo "Importing remote database ..."
+    $MYSQL < $FROM_DB_DATABASE.sql
+
+    echo "Cleaning up dumpfiles ..."
+    rm $FROM_DB_DATABASE.sql $TO_DB_DATABASE.sql
+
+    echo "Craft database pull complete!"
+}
+
+pull_craft_assets() {
+    echo "Pulling craft assets ..."
+
+    if [ $FROM_SSH_USER ]; then
+        for ASSET_PATH in $ASSET_PATHS; do
+            rsync -azL -e ssh $FROM_SSH_USER@$FROM_SSH_HOST:"${FROM_BASE_PATH}/${ASSET_PATH}/" "${TO_BASE_PATH}/${ASSET_PATH}/"
+        done
+    else
+        for ASSET_PATH in $ASSET_PATHS; do
+            rsync -azL "${FROM_BASE_PATH}/${ASSET_PATH}/" "${TO_BASE_PATH}/${ASSET_PATH}/"
+        done
+    fi
+
+    echo "Craft asset pull complete!"
+}
+
+clear_craft_caches() {
+    echo "Flushing all application caches ..."
+
+    $CRAFT_CMD cache/flush-all
+
+    echo "All craft caches cleared!"
+}
+
+main

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -1,0 +1,75 @@
+#
+# Configuration for the environment being pulled from.
+#
+
+FROM_SSH_USER="${FROM}_SSH_USER"
+FROM_SSH_USER="${!FROM_SSH_USER}"
+FROM_SSH_HOST="${FROM}_SSH_HOST"
+FROM_SSH_HOST="${!FROM_SSH_HOST}"
+FROM_BASE_PATH="${FROM}_BASE_PATH"
+FROM_BASE_PATH="${!FROM_BASE_PATH}"
+FROM_DB_DATABASE="${FROM}_DB_DATABASE"
+FROM_DB_DATABASE="${!FROM_DB_DATABASE}"
+FROM_DB_SERVER="${FROM}_DB_SERVER"
+FROM_DB_SERVER="${!FROM_DB_SERVER:-localhost}"
+FROM_DB_PORT="${FROM}_DB_PORT"
+FROM_DB_PORT="${!FROM_DB_PORT:-3306}"
+FROM_DB_USER="${FROM}_DB_USER"
+FROM_DB_USER="${!FROM_DB_USER}"
+FROM_DB_PASSWORD="${FROM}_DB_PASSWORD"
+FROM_DB_PASSWORD="${!FROM_DB_PASSWORD}"
+FROM_DB_TABLE_PREFIX="${FROM}_DB_TABLE_PREFIX"
+FROM_DB_TABLE_PREFIX="${!FROM_DB_TABLE_PREFIX}"
+
+#
+# Configuration for the environment being pulled to.
+#
+
+TO_BASE_PATH="BASE_PATH"
+TO_BASE_PATH=${!TO_BASE_PATH:-"$(pwd)/"}
+TO_SSH_USER="SSH_USER"
+TO_SSH_USER="${!TO_SSH_USER}"
+TO_SSH_HOST="SSH_HOST"
+TO_SSH_HOST="${!TO_SSH_HOST}"
+TO_DB_DATABASE="DB_DATABASE"
+TO_DB_DATABASE="${!TO_DB_DATABASE}"
+TO_DB_SERVER="DB_SERVER"
+TO_DB_SERVER="${!TO_DB_SERVER:-localhost}"
+TO_DB_PORT="DB_PORT"
+TO_DB_PORT="${!TO_DB_PORT:-3306}"
+TO_DB_USER="DB_USER"
+TO_DB_USER="${!TO_DB_USER}"
+TO_DB_PASSWORD="DB_PASSWORD"
+TO_DB_PASSWORD="${!TO_DB_PASSWORD}"
+TO_DB_TABLE_PREFIX="DB_TABLE_PREFIX"
+TO_DB_TABLE_PREFIX="${!TO_DB_TABLE_PREFIX}"
+
+#
+# Database variables.
+#
+
+# mysql / mysqldump commands to be executed against the current environment.
+MYSQL_CMD=${MYSQL_CMD:-"mysql"}
+MYSQL_CREDS="-u$TO_DB_USER -p$TO_DB_PASSWORD -P$TO_DB_PORT"
+MYSQLDUMP_CMD=${MYSQLDUMP_CMD:-"mysqldump"}
+MYSQL="$MYSQL_CMD $MYSQL_CREDS $TO_DB_DATABASE"
+MYSQLDUMP="$MYSQLDUMP_CMD $MYSQL_CREDS -Q --opt --add-drop-table --single-transaction --skip-lock-tables $TO_DB_DATABASE"
+
+# mysqldump command to be executed against the remote environment.
+FROM_MYSQLDUMP_CMD=${FROM_MYSQLDUMP_CMD:-"mysqldump"}
+FROM_MYSQL_CREDS="-u$FROM_DB_USER -p$FROM_DB_PASSWORD -P$FROM_DB_PORT"
+FROM_MYSQLDUMP="$FROM_MYSQLDUMP_CMD $FROM_MYSQL_CREDS -Q --opt --add-drop-table --single-transaction --skip-lock-tables $FROM_DB_DATABASE"
+
+#
+# Asset variables.
+#
+
+# Asset paths to pull relative to BASE_PATH.
+ASSET_PATHS=${ASSET_PATHS:-"public/uploads storage/rebrand"}
+
+#
+# Craft configuration.
+#
+
+# Craft CLI command.
+CRAFT_CMD=${CRAFT_CMD:-"./craft"}


### PR DESCRIPTION
# Description

Add scripts for use with new Craft config, that allow for stashing and popping local databases to `stash.sql.gz` file

## Related issues

`project.yaml` (I think that's all I need to say 🙃 )

## How to test

- make sure your `./backups` directory doesn't have a `stash.sql.gz` file in it
- make some things (entries, categories, etc.) and run `./bin/stash-db`, which should result in a `stash.sql.gz` file being created in the `./backups` directory
- restart Docker containers (`./bin/start`) and you none of those entries, categories, etc. should have persisted
- stop containers, run `./bin/pop-db` and `./bin/start`, and then check for the entries, categories, etc. that you created (which should now be present)
